### PR TITLE
set a specific version of debian

### DIFF
--- a/docker/build/Dockerfile.debian
+++ b/docker/build/Dockerfile.debian
@@ -1,4 +1,4 @@
-FROM debian:latest
+FROM debian:buster
 RUN apt-get update && apt install -y git wget libgstreamer-plugins-base1.0-dev libusb-1.0
 RUN wget https://golang.org/dl/go1.15.2.linux-amd64.tar.gz
 RUN tar -xvf go1.15.2.linux-amd64.tar.gz


### PR DESCRIPTION
from latest (which was true in 2020) to buster which will remains true in 6 years